### PR TITLE
Shutdown method

### DIFF
--- a/src/main/java/io/openraven/magpie/api/MagpiePlugin.java
+++ b/src/main/java/io/openraven/magpie/api/MagpiePlugin.java
@@ -52,6 +52,8 @@ public interface MagpiePlugin<T> {
    */
   void init(T config, Logger logger);
 
+  default void shutdown() {}
+
   /**
    * The class of the configuration object passed to {@link #init(Object, Logger)}
    * @return


### PR DESCRIPTION
Add an optional interface method to notify plugins of an impending shutdown. This allows cleanup of resources or flushing of cached content.

A default (no-op) implementation is provided so existing plugins do not need to implement this if the current behavior is suffcient.
